### PR TITLE
EVG-15505: remove deprecated maligned linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,7 +12,6 @@ linters:
     - govet
     - ineffassign
     - interfacer
-    - maligned
     - misspell
     - staticcheck
     - structcheck
@@ -31,9 +30,10 @@ run:
   exclude-use-default: false
   timeout: 10m
 
-linters-settings:
-  maligned:
-    suggest-new: true
+linter-settings:
+  govet:
+    enable:
+      - fieldalignment
 
 issues:
   exclude-rules:


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-15505

maligned is deprecated in favor of govet's fieldalignment linter.